### PR TITLE
Add the official router and several mixins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 - [@hyperapp/router](https://github.com/hyperapp/router) - The official router for Hyperapp.
 - [hyperapp-server](https://github.com/hyperapp/server) - Render Hyperapp statically from the server.
 - [hyperapp-transitions](https://github.com/zaceno/hyperapp-transitions) - Helps you animate transitions in your Hyperapp applications.
+- [picostyle](https://github.com/picostyle/picostyle) - A 0.3 KB CSS-in-JS library for use with Hyperapp & Picodom.
 
 ## Official Resources and Community
 - [Documentation](https://github.com/hyperapp/hyperapp/tree/master/docs) - Official Hyperapp documentation.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 - [hypernews](https://github.com/traducer/hypernews) - Hacker News clone with Hyperapp.
 
 ## Libraries and Mixins
+- [@hyperapp/logger](https://github.com/hyperapp/logger) - Logs state updates and action information to the console.
+- [@hyperapp/router](https://github.com/hyperapp/router) - The official router for Hyperapp.
+- [hyperapp-deepupdate](https://github.com/NoobLad/hyperapp-deepupdate) - A utility for updating deeply nested state.
+- [hyperapp-dot-notation-reducer](https://github.com/alber70g/hyperapp-dot-notation-reducer) - Allows actions to return an object with a path as a path as a property.
+- [hyperapp-firebase-auth](https://github.com/lukejacksonn/hyperapp-firebase-auth) - Drop in authentication for Hyperapp using Firebase.
+- [hyperapp-freeze](https://github.com/okwolf/hyperapp-freeze) - Deep freezes the state on load in development.
+- [hyperapp-hmr](https://github.com/scrapjs/hyperapp-hmr) - Hot module replacement for Hyperapp independent of the build process.
+- [hyperapp-html](https://github.com/swizz/hyperapp-html) - Html helpers for Hyperapp.
+- [hyperapp-partial](https://github.com/zaceno/hyperapp-partial) - Helps structure your code into related state properties, actions and events inside a namespace.
+- [hyperapp-persist](https://github.com/jamen/hyperapp-persist) - Store the state of Hyperapp in localStorage.
+- [hyperapp-redux-devtools](https://github.com/andyrj/hyperapp-redux-devtools) - Enables use of redux-devtools-extension for Hyperapp.
+- [hyperapp-server](https://github.com/hyperapp/server) - Render Hyperapp statically from the server.
 - [hyperapp-transitions](https://github.com/zaceno/hyperapp-transitions) - Helps you animate transitions in your Hyperapp applications.
 
 ## Resources and Others

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 - [deployable](https://github.com/lukejacksonn/deployable) - A ready-to-deploy static web app template built with Hyperapp.
 - [happy](https://github.com/zaceno/happy) - Happiness index calculator for teams, built with Hyperapp.
 - [hyperapp-boilerplate](https://github.com/tzellman/hyperapp-boilerplate) - Boilerplate showing how to create a production-ready Hyperapp application.
-- [hyperapp-electron](https://github.com/lukejacksonn/hyperapp-electron) - A minimal electron app starter with hyperapp, livereload and redux devtools
+- [hyperapp-electron](https://github.com/lukejacksonn/hyperapp-electron) - A minimal Electron app starter with Hyperapp, LiveReload and Redux DevTools.
 - [hyperapp-flow-skeleton](https://github.com/just-nobody/hyperapp-flow-skeleton) - A simple skeleton for getting started with Hyperapp, webpack, and flowtype.
 - [hyperapp-game-of-life](https://github.com/applefreak/hyperapp-game-of-life/) - An implementation of Conway's Game of Life in Hyperapp.
 - [hyperapp-one](https://github.com/selfup/hyperapp-one) - Simple Hyperapp webpack boilerplate counter app with Airbnb ESlint and JSX.
@@ -30,7 +30,7 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 - [hyperapp-firebase-auth](https://github.com/lukejacksonn/hyperapp-firebase-auth) - Drop in authentication for Hyperapp using Firebase.
 - [hyperapp-freeze](https://github.com/okwolf/hyperapp-freeze) - Deep freezes the state on load in development.
 - [hyperapp-hmr](https://github.com/scrapjs/hyperapp-hmr) - Hot module replacement for Hyperapp independent of the build process.
-- [hyperapp-html](https://github.com/swizz/hyperapp-html) - Html helpers for Hyperapp.
+- [hyperapp-html](https://github.com/swizz/hyperapp-html) - HTML helpers for Hyperapp.
 - [@hyperapp/logger](https://github.com/hyperapp/logger) - Logs state updates and action information to the console.
 - [hyperapp-partial](https://github.com/zaceno/hyperapp-partial) - Helps structure your code into related state properties, actions and events inside a namespace.
 - [hyperapp-persist](https://github.com/jamen/hyperapp-persist) - Store the state of Hyperapp in localStorage.
@@ -44,7 +44,7 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 - [Reddit](https://www.reddit.com/r/hyperapp/) - Official Hyperapp Subreddit.
 - [Slack](https://hyperappjs.herokuapp.com/) - Official Hyperapp community on Slack.
 - [Twitter](https://twitter.com/hyperappjs) - Official Hyperapp Twitter account.
-- [Codepen](https://codepen.io/hyperapp/) - Official Hyperapp Codepen account.
+- [CodePen](https://codepen.io/hyperapp/) - Official Hyperapp Codepen account.
 
 ## Other Resources
 - [How Hyperapp Works](https://gist.github.com/jbucaran/8dc33b7947f3193eb2ea3d5700e27036)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 ## Contents
 - [Apps and Boilerplates](#apps-and-boilerplates)
 - [Libraries and Mixins](#libraries-and-mixins)
-- [Resources and Others](#resources-and-others)
+- [Official Resources and Community](#official-resources-and-community)
+- [Other Resources](#other-resources)
 - [Contributing](#contributing)
 
 ## Apps and Boilerplates
@@ -13,6 +14,7 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 - [deployable](https://github.com/lukejacksonn/deployable) - A ready-to-deploy static web app template built with Hyperapp.
 - [happy](https://github.com/zaceno/happy) - Happiness index calculator for teams, built with Hyperapp.
 - [hyperapp-boilerplate](https://github.com/tzellman/hyperapp-boilerplate) - Boilerplate showing how to create a production-ready Hyperapp application.
+- [hyperapp-electron](https://github.com/lukejacksonn/hyperapp-electron) - A minimal electron app starter with hyperapp, livereload and redux devtools
 - [hyperapp-flow-skeleton](https://github.com/just-nobody/hyperapp-flow-skeleton) - A simple skeleton for getting started with Hyperapp, webpack, and flowtype.
 - [hyperapp-game-of-life](https://github.com/applefreak/hyperapp-game-of-life/) - An implementation of Conway's Game of Life in Hyperapp.
 - [hyperapp-one](https://github.com/selfup/hyperapp-one) - Simple Hyperapp webpack boilerplate counter app with Airbnb ESlint and JSX.
@@ -23,25 +25,32 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 - [hypernews](https://github.com/traducer/hypernews) - Hacker News clone with Hyperapp.
 
 ## Libraries and Mixins
-- [@hyperapp/logger](https://github.com/hyperapp/logger) - Logs state updates and action information to the console.
-- [@hyperapp/router](https://github.com/hyperapp/router) - The official router for Hyperapp.
 - [hyperapp-deepupdate](https://github.com/NoobLad/hyperapp-deepupdate) - A utility for updating deeply nested state.
 - [hyperapp-dot-notation-reducer](https://github.com/alber70g/hyperapp-dot-notation-reducer) - Allows actions to return an object with a path as a path as a property.
 - [hyperapp-firebase-auth](https://github.com/lukejacksonn/hyperapp-firebase-auth) - Drop in authentication for Hyperapp using Firebase.
 - [hyperapp-freeze](https://github.com/okwolf/hyperapp-freeze) - Deep freezes the state on load in development.
 - [hyperapp-hmr](https://github.com/scrapjs/hyperapp-hmr) - Hot module replacement for Hyperapp independent of the build process.
 - [hyperapp-html](https://github.com/swizz/hyperapp-html) - Html helpers for Hyperapp.
+- [@hyperapp/logger](https://github.com/hyperapp/logger) - Logs state updates and action information to the console.
 - [hyperapp-partial](https://github.com/zaceno/hyperapp-partial) - Helps structure your code into related state properties, actions and events inside a namespace.
 - [hyperapp-persist](https://github.com/jamen/hyperapp-persist) - Store the state of Hyperapp in localStorage.
 - [hyperapp-redux-devtools](https://github.com/andyrj/hyperapp-redux-devtools) - Enables use of redux-devtools-extension for Hyperapp.
+- [@hyperapp/router](https://github.com/hyperapp/router) - The official router for Hyperapp.
 - [hyperapp-server](https://github.com/hyperapp/server) - Render Hyperapp statically from the server.
 - [hyperapp-transitions](https://github.com/zaceno/hyperapp-transitions) - Helps you animate transitions in your Hyperapp applications.
 
-## Resources and Others
+## Official Resources and Community
 - [Documentation](https://github.com/hyperapp/hyperapp/tree/master/docs) - Official Hyperapp documentation.
 - [Reddit](https://www.reddit.com/r/hyperapp/) - Official Hyperapp Subreddit.
 - [Slack](https://hyperappjs.herokuapp.com/) - Official Hyperapp community on Slack.
 - [Twitter](https://twitter.com/hyperappjs) - Official Hyperapp Twitter account.
+- [Codepen](https://codepen.io/hyperapp/) - Official Hyperapp Codepen account.
+
+## Other Resources
+- [How Hyperapp Works](https://gist.github.com/jbucaran/8dc33b7947f3193eb2ea3d5700e27036)
+- [Pure Programming with Hyper App](https://glebbahmutov.com/blog/pure-programming-with-hyper-app/)
+- [HyperApp - Tiny Library for Frontend Applications - Interview with Jorge Bucaran](https://survivejs.com/blog/hyperapp-interview/)
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 
 ## Libraries and Mixins
 - [hyperapp-deepupdate](https://github.com/NoobLad/hyperapp-deepupdate) - A utility for updating deeply nested state.
-- [hyperapp-dot-notation-reducer](https://github.com/alber70g/hyperapp-dot-notation-reducer) - Allows actions to return an object with a path as a path as a property.
+- [hyperapp-dot-notation-reducer](https://github.com/alber70g/hyperapp-dot-notation-reducer) - Allows actions to return an object with a path as a property in order to edit deeply nested state.
 - [hyperapp-firebase-auth](https://github.com/lukejacksonn/hyperapp-firebase-auth) - Drop in authentication for Hyperapp using Firebase.
 - [hyperapp-freeze](https://github.com/okwolf/hyperapp-freeze) - Deep freezes the state on load in development.
 - [hyperapp-hmr](https://github.com/scrapjs/hyperapp-hmr) - Hot module replacement for Hyperapp independent of the build process.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 - [Contributing](#contributing)
 
 ## Apps and Boilerplates
-
 - [deployable](https://github.com/lukejacksonn/deployable) - A ready-to-deploy static web app template built with Hyperapp.
 - [happy](https://github.com/zaceno/happy) - Happiness index calculator for teams, built with Hyperapp.
 - [hyperapp-boilerplate](https://github.com/tzellman/hyperapp-boilerplate) - Boilerplate showing how to create a production-ready Hyperapp application.
@@ -48,10 +47,8 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 
 ## Other Resources
 - [How Hyperapp Works](https://gist.github.com/jbucaran/8dc33b7947f3193eb2ea3d5700e27036)
-- [Pure Programming with Hyper App](https://glebbahmutov.com/blog/pure-programming-with-hyper-app/)
-- [HyperApp - Tiny Library for Frontend Applications - Interview with Jorge Bucaran](https://survivejs.com/blog/hyperapp-interview/)
-
+- [Blog post on Hyperapp by Gleb Bahmutov](https://glebbahmutov.com/blog/pure-programming-with-hyper-app/)
+- [Interview with Jorge Bucaran](https://survivejs.com/blog/hyperapp-interview/)
 
 ## Contributing
-
 To contribute, fork this repository, add your amazing entry and send us a PR. See [CONTRIBUTING](/CONTRIBUTING.md) for more information.


### PR DESCRIPTION
I find this repo a useful starting point for Hyperapp but it needs some updating of the mixins/libraries. I have added the official router and several mixins which are also on npm. If this is too much at once, it would be nice to at least have the official router here. Seems a bit tedious though to make each mixin a separate pr.