### PR TITLE
Add golazon to "Apps and Boilerplates"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 
 ## Apps and Boilerplates
 - [deployable](https://github.com/lukejacksonn/deployable) - A ready-to-deploy static web app template built with Hyperapp.
+- [golazon.com](https://github.com/sobstel/golazon) - Football data mnmlist way. Built with Hyperapp and Hyperapp/Router.
 - [happy](https://github.com/zaceno/happy) - Happiness index calculator for teams, built with Hyperapp.
 - [hyperapp-boilerplate](https://github.com/tzellman/hyperapp-boilerplate) - Boilerplate showing how to create a production-ready Hyperapp application.
 - [hyperapp-electron](https://github.com/lukejacksonn/hyperapp-electron) - A minimal Electron app starter with Hyperapp, LiveReload and Redux DevTools.


### PR DESCRIPTION
Golazon project rewritten from riot to hyperapp in one day.