### PR TITLE
Replace hyperapp-partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 
 ## Contents
 - [Apps and Boilerplates](#apps-and-boilerplates)
-- [Libraries and Mixins](#libraries-and-mixins)
+- [Utilites](#utilities)
 - [Official Resources and Community](#official-resources-and-community)
 - [Other Resources](#other-resources)
 - [Contributing](#contributing)
@@ -24,15 +24,16 @@ A curated list of awesome projects built with [Hyperapp](https://github.com/hype
 - [hyperapp-wiki](https://github.com/lukejacksonn/hyperapp-wiki) - Example of how Hyperapp could be used to serve its own wiki with gh-pages.
 - [hypernews](https://github.com/traducer/hypernews) - Hacker News clone with Hyperapp.
 
-## Libraries and Mixins
+## Utilities
 - [hyperapp-deepupdate](https://github.com/NoobLad/hyperapp-deepupdate) - A utility for updating deeply nested state.
 - [hyperapp-dot-notation-reducer](https://github.com/alber70g/hyperapp-dot-notation-reducer) - Allows actions to return an object with a path as a property in order to edit deeply nested state.
+- [hyperapp-events](https://github.com/zaceno/hyperapp-events) - Adds an event-bus to your app for dependency-free cross-module communcations.
 - [hyperapp-firebase-auth](https://github.com/lukejacksonn/hyperapp-firebase-auth) - Drop in authentication for Hyperapp using Firebase.
 - [hyperapp-freeze](https://github.com/okwolf/hyperapp-freeze) - Deep freezes the state on load in development.
 - [hyperapp-hmr](https://github.com/scrapjs/hyperapp-hmr) - Hot module replacement for Hyperapp independent of the build process.
 - [hyperapp-html](https://github.com/swizz/hyperapp-html) - HTML helpers for Hyperapp.
 - [@hyperapp/logger](https://github.com/hyperapp/logger) - Logs state updates and action information to the console.
-- [hyperapp-partial](https://github.com/zaceno/hyperapp-partial) - Helps structure your code into related state properties, actions and events inside a namespace.
+- [hyperapp-module-views](https://github.com/hyperapp-module-views) - Lets your modules provide components bound to their state and actions.
 - [hyperapp-persist](https://github.com/jamen/hyperapp-persist) - Store the state of Hyperapp in localStorage.
 - [hyperapp-redux-devtools](https://github.com/andyrj/hyperapp-redux-devtools) - Enables use of redux-devtools-extension for Hyperapp.
 - [@hyperapp/router](https://github.com/hyperapp/router) - The official router for Hyperapp.


### PR DESCRIPTION
hyperapp-partial is not maintained and incompatible since v 0.13.0
Add two HOA I use to replace it: hyperapp-module-views and hyperapp-events
Since mixins are gone, change Libraries & Mixins to Utilities