### PR TITLE
Add TodoMVC example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ To contribute, fork this repository, add your amazing entry and send us a PR. Se
 
 * [RealWorld with Hyperapp](https://github.com/kwasniew/hyperapp2-real-world-example)
 * [7GUIs with Hyperapp](https://github.com/zaceno/sevenguis-hyperapp)
+* [TodoMVC with Hyperapp](https://github.com/zaceno/todomvc-hyperapp) – no-build, type-safe, spec-compliant implementation of TodoMVC
 
 ## Starters
 


### PR DESCRIPTION
TodoMVC is still a common standard for comparing and evaluating frontend frameworks and I think it would do well to have one in the awesome-list, even if unofficial. My example also demonstrates how we can use Hyperapp to make complete, type-safe, apps using nether bundlers nor transpilers.