### PR TITLE
add astro integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ To contribute, fork this repository, add your amazing entry and send us a PR. Se
 
 ## Utilities
 
+* [astrojs-hyperapp](https://github.com/zaceno/astrojs-hyperapp) - Use Hyperapp in Astro. Besides JSX/TSX, HMR & SSR, also supports state-synchronization across apps.
 * [hyperapp-router](https://github.com/mrozbarry/hyperapp-router) - A router for Hyperapp
 * [hyperapp-form](https://github.com/zaceno/hyperapp-form) - Eases the pain of validating & submitting forms
 * [hyperapp-styled-components](https://github.com/silentcicero/hyperapp-styled-components) - Component oriented CSS-in-JS system based on [styled-components](https://styled-components.com)


### PR DESCRIPTION
With this integration, Astro can be to Hyperapp what Next.js is to React (almost). 

Link: https://github.com/zaceno/astrojs-hyperapp